### PR TITLE
development と test のときのみ Dotenv を使う

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,9 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-Dotenv::Railtie.load
+if Rails.env.development? || Rails.env.test?
+  Dotenv::Railtie.load
+end
 
 module Sokuseki
   class Application < Rails::Application


### PR DESCRIPTION
Gemfile はそのようになっていたのだけれど、Rails 起動時に問答無用で読み込む処理になっていたので直します。