### PR TITLE
IssuesEvent の opened と closed を区別する

### DIFF
--- a/app/views/activities/github/_event.html.slim
+++ b/app/views/activities/github/_event.html.slim
@@ -73,9 +73,16 @@ li
   - when "IssuesEvent"
     - issue_title = data.dig("issue", "title")
     - issue_url = data.dig("issue", "html_url")
+    - action = data.dig("action")
     ' Issue
     => link_to issue_title, issue_url
-    | を立てた
+    - case action
+    - when "opened"
+      | を立てた
+    - when "closed"
+      | を閉じた
+    - else
+      = action
   - when "LabelEvent"
     | LabelEvent
   - when "MarketplacePurchaseEvent"


### PR DESCRIPTION
IssuesEvent はすべて「Issue を立てた」という表示になっていたので、区別する処理を入れる :muscle:
