### PR TITLE
IssueCommentEvent の表示を組み立てる際、Pull Request と Issue を区別する

### DIFF
--- a/app/views/activities/github/_event.html.slim
+++ b/app/views/activities/github/_event.html.slim
@@ -96,7 +96,6 @@ li
     | InstallationRepositoriesEvent
   - when "IssueCommentEvent"
     - issue_title = data.dig("issue", "title")
-    - comment_body = data.dig("comment", "body").to_s.gsub("\r\n", " ").gsub("\n", " ")[0..50]
     - comment_url = data.dig("comment", "html_url")
     => data.dig('issue', 'pull_request') ? 'Pull Request' : 'Issue'
     => link_to issue_title, comment_url

--- a/app/views/activities/github/_event.html.slim
+++ b/app/views/activities/github/_event.html.slim
@@ -98,7 +98,7 @@ li
     - issue_title = data.dig("issue", "title")
     - comment_body = data.dig("comment", "body").to_s.gsub("\r\n", " ").gsub("\n", " ")[0..50]
     - comment_url = data.dig("comment", "html_url")
-    ' Issue
+    => data.dig('issue', 'pull_request') ? 'Pull Request' : 'Issue'
     => link_to issue_title, comment_url
     | にコメントした
   - when "IssuesEvent"


### PR DESCRIPTION
Pull Request にコメントを投稿した場合も IssueCommentEvent として扱われてしまうので、こちらで区別する。