### PR TITLE
作成した Issue と Pull Request の一覧を Markdown の箇条書きで出力する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -199,13 +199,9 @@ Style/AndOr:
 Style/AsciiComments:
   Enabled: false
 
-# do .. end から更にメソッドチェーンすると見づらいので
-# auto-correct せず、自分で修正する
-# spec 内は見た目が綺麗になるので許可
+# ブロックの { .. } / do .. end は好きなように
 Style/BlockDelimiters:
-  AutoCorrect: false
-  Exclude:
-    - "spec/**/*_spec.rb"
+  Enabled: false
 
 # option 等、明示的にハッシュにした方が分かりやすい場合もある
 Style/BracesAroundHashParameters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -302,6 +302,10 @@ Style/MixinUsage:
     - "spec/dummy/bin/setup"
     - "spec/dummy/bin/update"
 
+# 複数行ブロックはお好きなように
+Style/MultilineBlockChain:
+  Enabled: false
+
 # 1_000_000 と区切り文字が 2 個以上必要になる場合のみ _ 区切りを必須にする
 # 10_000_00 は許可しない。(これは例えば 10000 ドルをセント単位にする時に便利だが
 # 頻出しないので foolproof に振る

--- a/app/controllers/activities/on_month_controller.rb
+++ b/app/controllers/activities/on_month_controller.rb
@@ -4,5 +4,13 @@ class Activities::OnMonthController < ApplicationController
   def index
     @month_string = params[:month_string]
     @activities = current_user.activities.on(@month_string)
+
+    @markdown_content = @activities.issue_and_pr.order(:acted_at).reject { |activity|
+      activity.activity_type == "IssuesEvent" && activity.original_data["action"] != "opened"
+    }.map { |activity|
+      data = activity.original_data
+      target = activity.activity_type == 'IssuesEvent' ? data["issue"] : data["pull_request"]
+      "- [%s](%s)" % [target["title"], target["html_url"]]
+    }.join("\n")
   end
 end

--- a/app/controllers/activities/on_month_controller.rb
+++ b/app/controllers/activities/on_month_controller.rb
@@ -4,13 +4,5 @@ class Activities::OnMonthController < ApplicationController
   def index
     @month_string = params[:month_string]
     @activities = current_user.activities.on(@month_string)
-
-    @markdown_content = @activities.issue_and_pr.order(:acted_at).reject { |activity|
-      activity.activity_type == "IssuesEvent" && activity.original_data["action"] != "opened"
-    }.map { |activity|
-      data = activity.original_data
-      target = activity.activity_type == 'IssuesEvent' ? data["issue"] : data["pull_request"]
-      "- [%s](%s)" % [target["title"], target["html_url"]]
-    }.join("\n")
   end
 end

--- a/app/helpers/activities_helper.rb
+++ b/app/helpers/activities_helper.rb
@@ -1,0 +1,11 @@
+module ActivitiesHelper
+  def markdown_list(activities)
+    activities.reject { |activity|
+      activity.activity_type == "IssuesEvent" && activity.original_data["action"] != "opened"
+    }.map { |activity|
+      data = activity.original_data
+      target = activity.activity_type == "IssuesEvent" ? data["issue"] : data["pull_request"]
+      "- [%s](%s)" % [target["title"], target["html_url"]]
+    }.join("\n")
+  end
+end

--- a/app/helpers/activities_helper.rb
+++ b/app/helpers/activities_helper.rb
@@ -5,7 +5,7 @@ module ActivitiesHelper
     }.map { |activity|
       data = activity.original_data
       target = (activity.activity_type == "IssuesEvent") ? data["issue"] : data["pull_request"]
-      "- [%{title}](%{url})" % { title: target["title"], url: target["html_url"] }
+      "- [%<title>s}](%<url>s)" % { title: target["title"], url: target["html_url"] }
     }.join("\n")
   end
 end

--- a/app/helpers/activities_helper.rb
+++ b/app/helpers/activities_helper.rb
@@ -4,8 +4,8 @@ module ActivitiesHelper
       activity.activity_type == "IssuesEvent" && activity.original_data["action"] != "opened"
     }.map { |activity|
       data = activity.original_data
-      target = activity.activity_type == "IssuesEvent" ? data["issue"] : data["pull_request"]
-      "- [%s](%s)" % [target["title"], target["html_url"]]
+      target = (activity.activity_type == "IssuesEvent") ? data["issue"] : data["pull_request"]
+      "- [%{title}](%{url})" % { title: target["title"], url: target["html_url"] }
     }.join("\n")
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -9,4 +9,8 @@ class Activity < ApplicationRecord
   scope :on, ->(month_string) {
     where(acted_at: Time.zone.parse("#{month_string}-01").all_month)
   }
+
+  scope :issue_and_pr, -> {
+    where(activity_type: %w[IssuesEvent PullRequestEvent])
+  }
 end

--- a/app/views/activities/on_month/index.html.slim
+++ b/app/views/activities/on_month/index.html.slim
@@ -9,6 +9,10 @@ ul
     li
       = "#{activity_type} : #{count}"
 h3
+  | Issue と Pull Request を Markdown で
+p
+  = text_area_tag(:markdown, @markdown_content, rows: 20, style: 'width: 100%;')
+h3
   | 一覧
 ul
   = render partial: "activities/github/event", collection: @activities.order(:acted_at), as: :activity

--- a/app/views/activities/on_month/index.html.slim
+++ b/app/views/activities/on_month/index.html.slim
@@ -11,7 +11,8 @@ ul
 h3
   | Issue と Pull Request を Markdown で
 p
-  = text_area_tag(:markdown, @markdown_content, rows: 20, style: 'width: 100%;')
+  - text = markdown_list(@activities.issue_and_pr.order(:acted_at))
+  = text_area_tag(:markdown, text, rows: 20, style: 'width: 100%;')
 h3
   | 一覧
 ul


### PR DESCRIPTION
ふりかえり資料をつくるとき、しばしば作成した Issue と Pull Request の一覧を Markdown の箇条書きにしてまとめます。それをシュッとできるようにしちゃいます。
