### PR TITLE
アクティビティをマークダウン出力するときのPRタイトルに余計な中括弧が含まれているので消す

### DIFF
--- a/app/helpers/activities_helper.rb
+++ b/app/helpers/activities_helper.rb
@@ -6,7 +6,7 @@ module ActivitiesHelper
       data = activity.original_data
       target = (activity.activity_type == "IssuesEvent") ? data["issue"] : data["pull_request"]
 
-      "- [%<title>s}](%<url>s)" % { title: target["title"], url: target["html_url"] }
+      "- [%<title>s](%<url>s)" % { title: target["title"], url: target["html_url"] }
     }.uniq.join("\n")
   end
 end


### PR DESCRIPTION
アクティビティのマークダウン表示（Issue と Pull Request を Markdown で
）のIssue,PRのタイトル部分に余計な中括弧が含まれているので消します。

修正前
```
- [ほげほげ}](https://www.example.com/issues/1)
```

修正後
```
- [ほげほげ](https://www.example.com/issues/1)
```