### PR TITLE
チャートの凡例に `Event` が連続してて見にくいので削除する

### DIFF
--- a/app/views/activities/on_month/index.html.slim
+++ b/app/views/activities/on_month/index.html.slim
@@ -34,7 +34,7 @@ javascript:
     let i = 0
     for (let key in activities) {
       datasets.push({
-        label: key,
+        label: key.replace('Event', ''),
         data: [activities[key]],
         backgroundColor: colorPalettes[i % colorPalettes.length]
       })


### PR DESCRIPTION
https://github.com/june29/sokuseki/issues/13#issuecomment-465594917 の

> 各種イベント名の末尾の `Event` は空文字列に置換しちゃうといいかもね〜

をやってみました！

(ついでに今までforkでブランチを生やしてたのを、直接ブランチを生やす方にしていく試運転も兼ねて 🐙 )

---

こんな感じになりますイメージ
![image](https://user-images.githubusercontent.com/13295106/53099573-70187500-3569-11e9-9e6b-b8710ec0edbf.png)
