### PR TITLE
📝 Change Logを導入して、リリース内容をわかりやすくする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Docker起動時に、tmp/pids/server.pid を削除する #77
 
-## [1.0.0] - 2019-02-16
+## 1.0.0 - 2019-02-16
 ### Added
 - initial release!
 
 [Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.0...HEAD
-[1.0.0]: https://github.com/june29/sokuseki/compare/v1.0.0...v1.1.0
+[1.1.0]: https://github.com/june29/sokuseki/compare/v1.0.0...v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-- Changelogを導入
 
 ## [1.1.0] - 2019-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Changelogを導入
+
+## [1.1.0] - 2019-02-23
+
+### Added
+- 月別アクティビティのチャート表示 #75 #78
+
+### Changed
+- Docker起動時に、tmp/pids/server.pid を削除する #77
+
+## [1.0.0] - 2019-02-16
+### Added
+- initial release!
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.0...HEAD
+[1.0.0]: https://github.com/june29/sokuseki/compare/v1.0.0...v1.1.0


### PR DESCRIPTION
### やったこと
- これまでの開発に対して、 https://github.com/june29/sokuseki/releases で2つrelease tag(と呼ぶのかな？)を打った
  - チャート表示のところを1.1.0にするとして、その前を1.0.0とする形で打った
- release tag に対して、 `CHANGELOG.md` を作成した
  - フォーマットは[Keep a Changelog](https://keepachangelog.com/en/1.0.0/) をベースに手動で書いた

### レビューポイント
- Change Logを導入したのが初めてなので、おかしなところがなさそうか

---

### 試したこと
- 自動化できないかなあと思って、 [Go製のCHANGELOGジェネレータを作った - wadackel.me](https://blog.wadackel.me/2018/git-chglog/) を試してみたが、コミットメッセージから内容を取ってきてChange Logを生成するようだったので、現状だとそぐわないのかなと思って使わなかった