### PR TITLE
👋 使っていないstrategyにお別れする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.1.0] - 2019-02-23
+- 使用していないomniauthのstrategy (developer) を削除 [👋 使っていないstrategyにお別れする by yinm · Pull Request #88 · june29/sokuseki](https://github.com/june29/sokuseki/pull/88)
 
 ### Added
 - 月別アクティビティのチャート表示 [#75](https://github.com/june29/sokuseki/pull/75) [#78](https://github.com/june29/sokuseki/pull/78)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- 使用していないomniauthのstrategy (developer) を削除 [👋 使っていないstrategyにお別れする by yinm · Pull Request #88 · june29/sokuseki](https://github.com/june29/sokuseki/pull/88)
 
 ## [1.1.0] - 2019-02-23
-- 使用していないomniauthのstrategy (developer) を削除 [👋 使っていないstrategyにお別れする by yinm · Pull Request #88 · june29/sokuseki](https://github.com/june29/sokuseki/pull/88)
 
 ### Added
 - 月別アクティビティのチャート表示 [#75](https://github.com/june29/sokuseki/pull/75) [#78](https://github.com/june29/sokuseki/pull/78)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 月別アクティビティのチャート表示 [#75](https://github.com/june29/sokuseki/pull/75) [#78](https://github.com/june29/sokuseki/pull/78)
 
 ### Changed
-- Docker起動時に、tmp/pids/server.pid を削除する [#77](https://github.com/june29/sokuseki/pull/77)
+- Docker起動時に、tmp/pids/server.pid を削除 [#77](https://github.com/june29/sokuseki/pull/77)
 
 ## 1.0.0 - 2019-02-16
 ### Added

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,4 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :developer unless Rails.env.production?
-
   ghe_host = ENV["GHE_HOST"]
 
   provider :github, ENV["GHE_APP_KEY"], ENV["GHE_APP_SECRET"], {


### PR DESCRIPTION
omniauthの`developer`は使ってなさそう (現状だと、routingの設定を追加したりとかをしないと使えない)。
さらに、使えるようにするメリットがそこまでなさそう (アクティビティが取れないので、開発に着手しづらそう)。

という理由から、削除しました。